### PR TITLE
Add new lines to dynamic reconfiguration change info

### DIFF
--- a/include/diff_drive_controller/diff_drive_controller.h
+++ b/include/diff_drive_controller/diff_drive_controller.h
@@ -230,8 +230,8 @@ namespace diff_drive_controller{
            //
            << "\tPublication parameters:\n"
            << "\t\tPublish executed velocity command: " << (params.publish_cmd?"enabled":"disabled") << "\n"
-           << "\t\tPublication rate: " << params.publish_rate                 << "\n"
-           << "\t\tPublish frame odom on tf: " << (params.enable_odom_tf?"enabled":"disabled")
+           << "\t\tPublication rate: " << params.publish_rate                                        << "\n"
+           << "\t\tPublish frame odom on tf: " << (params.enable_odom_tf?"enabled":"disabled")       << "\n"
            //
            << "\tVelocity parameters:\n"
            << "\t\tEmergency brake: " << (params.emergency_brake?"enabled":"disabled");

--- a/include/diff_drive_controller/diff_drive_controller.h
+++ b/include/diff_drive_controller/diff_drive_controller.h
@@ -231,7 +231,11 @@ namespace diff_drive_controller{
            << "\tPublication parameters:\n"
            << "\t\tPublish executed velocity command: " << (params.publish_cmd?"enabled":"disabled") << "\n"
            << "\t\tPublication rate: " << params.publish_rate                 << "\n"
-           << "\t\tPublish frame odom on tf: " << (params.enable_odom_tf?"enabled":"disabled");
+           << "\t\tPublish frame odom on tf: " << (params.enable_odom_tf?"enabled":"disabled")
+           //
+           << "\tVelocity parameters:\n"
+           << "\t\tEmergency brake: " << (params.emergency_brake?"enabled":"disabled");
+
 
         return os;
       }

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>diff_drive_controller</name>
-  <version>0.20.1</version>
+  <version>0.20.2</version>
   <description>Controller for a differential drive mobile base.</description>
 
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>


### PR DESCRIPTION
I added the new headline "Velocity parameters" and our new emergency brake parameter to the info message. It prints from the tmux's base.launch terminal when the diagnostics change the parameter.

![Screenshot from 2023-03-08 11-28-32](https://user-images.githubusercontent.com/24641966/223683898-df0d6ac8-4d1e-42fa-8703-bdcaae26d3d5.png)
![Screenshot from 2023-03-08 11-28-48](https://user-images.githubusercontent.com/24641966/223683905-1170fcc2-75b4-4cb1-a8af-382a7c25272e.png)
